### PR TITLE
Add song structure (phrases)

### DIFF
--- a/src/main/kaitai/rekordbox_anlz.ksy
+++ b/src/main/kaitai/rekordbox_anlz.ksy
@@ -334,7 +334,7 @@ types:
             'phrase_style::verse_bridge': phrase_verse_bridge
         doc: |
           Identifier of the phrase label.
-      - size: 18
+      - size: _parent.len_entry_bytes - 6
 
   phrase_up_down:
     seq:


### PR DESCRIPTION
This adds basic support for phrase analysis data (PSSI tags).

A few things to note:
- Rekordbox categorizes a track into one of two phrase styles: Either up-down (white label text) which (besides intro and outro) has phrases like UP1, DOWN, and CHORUS2, or verse-bridge (black label text) which has phrases like VERSE1, VERSE2, BRIDGE, and CHORUS.
- I haven't figured out how the numbering in the up-down style is assigned. It doesn't seem to be encoded in the data. There can be several phrases of one type like UP1, UP2, UP3, etc. but they all get the same ID (unlike VERSE1, VERSE2, etc in the verse-bridge style). Also, the phrase numbering doesn't always start at one.
- The value 4 is not mapped in the up-down-style, leaving a gap between DOWN and CHORUS.
- Although the number of possible phrase types is 10 for both styles (INTRO1-2, UP1-3, CHORUS1-2, DOWN, OUTRO1-2 vs. INTRO, VERSE1-6, BRIDGE, CHORUS, OUTRO), they are not mapped identically 🙄 
- There are some unknown fields in both the header and the entry structures.
- Perhaps there exists a better alternative in Kaitai to the switch on the `phrase_id`.