### PR TITLE
Add fill-in support

### DIFF
--- a/src/main/kaitai/rekordbox_anlz.ksy
+++ b/src/main/kaitai/rekordbox_anlz.ksy
@@ -415,7 +415,15 @@ types:
             'phrase_style::verse_bridge': phrase_verse_bridge
         doc: |
           Identifier of the phrase label.
-      - size: _parent.len_entry_bytes - 6
+      - size: _parent.len_entry_bytes - 9
+      - id: fill_in
+        type: u1
+        doc: |
+          If nonzero, fill-in is present.
+      - id: fill_in_beat_number
+        type: u2
+        doc: |
+          The beat number at which fill-in starts.
 
   phrase_up_down:
     seq:


### PR DESCRIPTION
This adds support for fill-in. Fill-in, if present, is displayed as little dots on the full waveform at the end of a phrase. The manual says:

> [Fill in] is a section that provides improvisational changes at the end of phrase. [Fill in] is
detected at the end of Intro, Up, and Chorus (up to 4 beats).