### PR TITLE
Add end_beat and phrase style 3

### DIFF
--- a/src/main/kaitai/rekordbox_anlz.ksy
+++ b/src/main/kaitai/rekordbox_anlz.ksy
@@ -388,8 +388,17 @@ types:
           (white label text in rekordbox) where the main phrases consist
           of up, down, and chorus. 2 is the bridge-verse style
           (black label text in rekordbox) where the main phrases consist
-          of verse, chorus, and bridge.
-      - size: 12
+          of verse, chorus, and bridge. Style 3 is mostly identical to
+          bridge-verse style except verses 1-3 are labeled VERSE1 and verses
+          4-6 are labeled VERSE2 in rekordbox.
+      - size: 6
+      - id: end_beat
+        type: u2
+        doc: |
+          The beat number at which the last phrase ends. The track may
+          continue after the last phrase ends. If this is the case, it will
+          mostly be silence.
+      - size: 4
       - id: entries
         type: song_structure_entry
         repeat: expr
@@ -413,6 +422,7 @@ types:
           cases:
             'phrase_style::up_down': phrase_up_down
             'phrase_style::verse_bridge': phrase_verse_bridge
+            _: phrase_verse_bridge
         doc: |
           Identifier of the phrase label.
       - size: _parent.len_entry_bytes - 9


### PR DESCRIPTION
In rare cases a third phrase style can occur. Phrases in this style are displayed in even more subdued colors than bridge-verse style. The only difference to bridge-verse style is that verses 1-3 and 4-6 are merged into VERSE1 and VERSE2 resp. I have used the default case in the switch (`_`) for this to be on the safe side should there be other phrase style we don't know yet. I have not added another enum for this style since it's rare and mostly identical to the bridge-verse style (plus you can't have the same label for different numbers in an enum :)

Also, I have identified another field from the header. This is the beat number where last phrase ends. The end of all phrases except the last one is implicitly defined by the start of the following phrase. The last phrase, however, can end before the track ends (mostly silence).