### PR TITLE
Add color_id for extended cue memory cues and loops

### DIFF
--- a/src/main/kaitai/rekordbox_anlz.ksy
+++ b/src/main/kaitai/rekordbox_anlz.ksy
@@ -244,7 +244,12 @@ types:
         doc: |
           The position, in milliseconds, at which the player loops
           back to the cue time if this is a loop.
-      - size: 12  # Loops seem to have some non-zero values in the last four bytes of this.
+      - id: color_id
+        type: u1
+        doc: |
+          References a row in the colors table if the memory cue or loop
+          has been assigned a color
+      - size: 11  # Loops seem to have some non-zero values in the last four bytes of this.
       - id: len_comment
         type: u4
         if: len_entry > 43


### PR DESCRIPTION
Whilst integrating Create Digger based Rekordbox export media into [Mixxx](https://github.com/mixxxdj/mixxx) found that `cue_extended_tag_t.color_code`, `cue_extended_tag_t.color_red`, `cue_extended_tag_t.color_green`, `cue_extended_tag_t.color_blue` are correct for imported hotcues, however contained junk for memory cues and loops.

`cue_extended_tag_t.color_id` now gives a correct color table value, as used when also coloring tracks.