### PR TITLE
Fix .ksy file syntax highlighting on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-*.ksy linguist-language=KaitaiStruct
-*.ksy linguist-detectable=true


### PR DESCRIPTION
Since GitHub recognizes the `.ksy` file extension out of the box (https://github.com/github/linguist/pull/4830),
it is no longer needed to specify the language in `.gitattributes` manually.