### PR TITLE
Add active loop

### DIFF
--- a/doc/modules/ROOT/pages/anlz.adoc
+++ b/doc/modules/ROOT/pages/anlz.adoc
@@ -215,8 +215,8 @@ If the cue is an ordinary memory point, __hot_cue__ at
 bytes{nbsp}``0c``-`0f` will be zero, otherwise it identifies the
 number of the hot cue that this entry represents (Hot Cue A is number
 1, B is 2, and so on). The __status__ value at bytes{nbsp}``10``-`13`
-seems to be a deletion indicator; if it is zero, the entry is ignored.
-Cues which the players pay attention to have the value 1 here.
+is an indicator of active loops; if it is zero, the entry is a regular
+cue point or loop. Active loops have the value 4 here.
 
 The next four bytes have an unknown purpose, but seem to always have
 the value `00100000`. They are followed by two two-byte values, which

--- a/src/main/kaitai/rekordbox_anlz.ksy
+++ b/src/main/kaitai/rekordbox_anlz.ksy
@@ -571,11 +571,12 @@ enums:
     1: hot_cues
 
   cue_entry_type:
-    1: cue
+    1: memory_cue
     2: loop
 
   cue_entry_status:
-    0: default
+    0: disabled
+    1: enabled
     4: active_loop
 
   track_mood:

--- a/src/main/kaitai/rekordbox_anlz.ksy
+++ b/src/main/kaitai/rekordbox_anlz.ksy
@@ -167,7 +167,7 @@ types:
         type: u4
         enum: cue_entry_status
         doc: |
-          If zero, this entry should be ignored.
+          Indicates if this is an active loop.
       - type: u4  # Seems to always be 0x10000
       - id: order_first
         type: u2
@@ -238,7 +238,7 @@ types:
         type: u1
         enum: cue_entry_type
         doc: |
-          Indicates whether this is a memory cue or a loop.
+          Indicates whether this is a regular cue point or a loop.
       - size: 3  # seems to always be 1000
       - id: time
         type: u4
@@ -571,12 +571,12 @@ enums:
     1: hot_cues
 
   cue_entry_type:
-    1: memory_cue
+    1: cue
     2: loop
 
   cue_entry_status:
-    0: disabled
-    1: enabled
+    0: default
+    4: active_loop
 
   track_mood:
     1: high


### PR DESCRIPTION
I believe the current interpretation of `cue_entry_status` is wrong. I have observed that this field is zero for regular cue points and loops and 4 for active (memory cue) loops. This behavior corresponds with rekordbox's database where the `Kind` column in table `djmdCue` is 0 for memory cue points, 1,2,3,5,... for hot cue points, and 4 for active loop memory cues (there is an extra column `ActiveLoop` that's only for hot cues). Can you even disable a cue point?

Value 1 for  `cue_entry_type` also applies to hot cues, not only to memory cue points.

It seems that active loop hot cues are not exported as such but as regular hot cue loops instead. In rekordbox performance mode you can enable/disable active loop hot cues (loop icon turns red if loop is active) but if you switch to export mode they no longer appear red but orange like regular loops. The export files remain identical.

Another peculiar observation is that the new `.2EX` file only appears if an active loop is in the track. If you only have regular loops, the `.2EX` file disappears altogether. Perhaps the waveform information in the `.2EX` (`PWV7`, `PWV6`, `PWVC`) contains the red line that's shown in rekordbox for active loops.