### PR TITLE
Fix device sql strings

### DIFF
--- a/src/main/kaitai/rekordbox_pdb.ksy
+++ b/src/main/kaitai/rekordbox_pdb.ksy
@@ -891,12 +891,11 @@ types:
             _: device_sql_short_ascii(length_and_kind)
         -webide-parse-mode: eager
     -webide-representation: '{body.text}'
-
   device_sql_short_ascii:
     doc: |
       An ASCII-encoded string up to 127 bytes long.
     params:
-      - id: mangled_length
+      - id: length_and_kind
         type: u1
         doc: |
           Contains the actual length, incremented, doubled, and
@@ -904,16 +903,15 @@ types:
     seq:
       - id: text
         type: str
-        size: length
+        size: length - 1
         encoding: ascii
-        if: '(mangled_length % 2 > 0) and (length >= 0)'  # Skip invalid strings
         doc: |
           The content of the string.
     instances:
       length:
-        value: '((mangled_length - 1) / 2) - 1'
+        value: '(length_and_kind >> 1)'
         doc: |
-          The un-mangled length of the string, in bytes.
+          the length extracted of the entire device_sql_short_ascii type
         -webide-parse-mode: eager
 
   device_sql_long_ascii:

--- a/src/main/kaitai/rekordbox_pdb.ksy
+++ b/src/main/kaitai/rekordbox_pdb.ksy
@@ -891,6 +891,7 @@ types:
             _: device_sql_short_ascii(length_and_kind)
         -webide-parse-mode: eager
     -webide-representation: '{body.text}'
+
   device_sql_short_ascii:
     doc: |
       An ASCII-encoded string up to 127 bytes long.
@@ -922,9 +923,10 @@ types:
         type: u2
         doc: |
           Contains the length of the string in bytes.
+      - type: u1
       - id: text
         type: str
-        size: length
+        size: length - 4
         encoding: ascii
         doc: |
           The content of the string.


### PR DESCRIPTION
I'm not proficient enough in the kaitai struct DSL to implement something more complex, but at least with this simple solution there are no API changes. 