### PR TITLE
Don't seek past EOF. Limit to pages in file.

### DIFF
--- a/src/main/kaitai/rekordbox_pdb.ksy
+++ b/src/main/kaitai/rekordbox_pdb.ksy
@@ -141,6 +141,7 @@ types:
         pos: _root.len_page * index
         size: _root.len_page
         type: page
+        if: index < _root.tables[_root.num_tables-1].empty_candidate
 
   page:
     doc: |


### PR DESCRIPTION
Hi,

Love your work.

I was having problems loading pdb files because it was trying to seek past the end of the file loading pages that did not exist. I don't have an extensive library of export.pdb files so I don't know if this is totally valid, but I'm hoping someone with more can test this out. You'd think that rekordbox_pdb.empty_candidate, would be the number of pages, but that's false. I can provide a export.pdb showing this. Because of that we have to find it in the tables. there's no guarantee that empty_candidate of the last table is the last one, unfortunately but I wanted to at least open the conversation, in case someone else has fought this.

-s