### PR TITLE
Stop PDB table scans when `next_page` reaches a different page type

### DIFF
--- a/src/main/java/org/deepsymmetry/cratedigger/DatabaseUtil.java
+++ b/src/main/java/org/deepsymmetry/cratedigger/DatabaseUtil.java
@@ -103,6 +103,13 @@ class DatabaseUtil implements Closeable {
                     // logger.info("Indexing page " + currentRef.index());
                     final RekordboxPdb.Page page = currentRef.body();
 
+                    // Stop if following next_page has taken us to a page from another table.
+                    // This is one of the termination conditions for PDB table scans documented
+                    // in the Kaitai specification.
+                    if (page.type() != type) {
+                        break;
+                    }
+
                     // Process only ordinary data pages.
                     if (page.isDataPage()) {
                         for (RekordboxPdb.RowGroup rowGroup : page.rowGroups()) {
@@ -152,6 +159,13 @@ class DatabaseUtil implements Closeable {
                 do {
                     // logger.info("Indexing page " + currentRef.index());
                     final RekordboxPdb.Page page = currentRef.body();
+
+                    // Stop if following next_page has taken us to a page from another table.
+                    // This is one of the termination conditions for PDB table scans documented
+                    // in the Kaitai specification.
+                    if (page.typeExt() != type) {
+                        break;
+                    }
 
                     // Process only ordinary data pages.
                     if (page.isDataPage()) {


### PR DESCRIPTION
## Summary

This change makes `DatabaseUtil.indexRows(...)` stop scanning a PDB table when a followed `next_page` link reaches a page whose stored type does not match the table being indexed.

This implements the termination condition already documented in the Kaitai specification and avoids making an otherwise readable database fail completely when a damaged or stale page chain for one table points into an empty page or a page from a different table.

## Background

I encountered a real `export.pdb` where the main track metadata, artists, artwork, playlists, and folders could be indexed, but the history tables had inconsistent page chains. The history table pointer declared a valid `last_page`, but following `next_page` never reached that page. Instead, the chain reached an empty page whose type did not match the table, then continued toward an out-of-file page, resulting in an `EOFException` while indexing history playlists.

The file format documentation already describes two termination conditions for a table scan:

1. Stop when the scan reaches the table's `last_page`.
2. Stop when the `next_page` link reaches a page of a different type.

### Specification references

The Kaitai specification for `table.last_page` says:

> When following the linked list of pages of the table, you either need to stop when you reach this page, or when you notice that the `next_page` link you followed took you to a page of a different `type`.

Permalink: https://github.com/Deep-Symmetry/crate-digger/blob/d95c444bde4bec6763cbbffd1a405dda0cc08750/src/main/kaitai/rekordbox_pdb.ksy#L133-L135

The structure analysis document also describes table pages as a linked list, explains that `last_page` prevents following a link into pages of a different table, and notes that the per-page `type` field may be used as an alternate way to tell, when following page links, that the end of the desired table has been reached.

Reference: *Rekordbox Export Structure Analysis*, Section 1.1 “Database Exports” and Section 1.2 “Table Pages”: https://deepsymmetry.org/cratedigger/Analysis.pdf

## Possible fix

The idea is to add the above as an additional stopping condition. This would avoid failing the parsing on such tables.

Arguably the table is partially corrupted and not failing here is a silent fail, which would be bad, and I'm very open to this PR being closed for this reason
But if history tables being corrupted happens in real-world cases for history tables because of e.g. a buggy firmware on the DJ decks, USB drives being forcibly removed at the wrong time, etc... it's very hurtful to then not be able to read the whole rest of the database just for this reason, as that prevents getting track information, waveform, etc, from Beat Link / Beat Link Trigger. This is why I'm still proposing it. I have tested that it does fix parsing for my file.

An alternative implementation could be to just allow disabling parsing history tables, and make Beat Link / Beat Link Trigger not parse those because we don't care.

## Implementation

Update both overloads of `DatabaseUtil.indexRows(...)`:

If the page type does not match, break out of the table-page scan before processing rows or following the mismatched page's `next_page`.

This keeps the existing `last_page` behavior unchanged, while adding the second documented stopping condition.

## Behavior

Before this change, a table whose page chain reaches a page of another type can continue following unrelated `next_page` links and may eventually attempt to read past the end of the file.

After this change, table scans stop at the first page whose type differs from the table type being indexed. The database can still be used for metadata that was successfully indexed before the damaged or stale tail of the page chain.
