### PR TITLE
Document .2EX analysis file tags and correct 3-band waveform byte order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This change log follows the conventions of
 
 ### Fixed
 
+- Documented the tags found in `.2EX` analysis files, and corrected the order of the three bands in `PWV6` and `PWV7` waveform entries: analysis of a frequency sweep shows they are stored in low, mid-range, high order, not mid-range, high, low as previously documented (and still claimed by the protocol analysis, so this is worth checking in your own code).
+  Also added a section describing the `PWVC` calibration tag that can accompany the 3-band waveforms (resolving issue #22).
+
 - Reworked the database export Kaitai Struct definition to incorporate some important discoveries by the [Mixxx](https://mixxx.org) and [rekordcrate](https://github.com/Holzhaus/rekordcrate) developers (thanks once again [@Swiftb0y](https://github.com/Swiftb0y)): all tables that use string offsets have subtypes which control whether those offsets are eight or sixteen bits.
   We had previously only noted that for the Artists table, but the Album, Tag, and Tag Track tables behave this way as well, and in fact even the Track table follows this pattern, but its offsets always use the sixteen bit variant because the rows are so big.
 - The understanding of row counts in DeviceSQL data pages has been broken since the very beginning (though we had some clumsy workarounds that were good enough for reading).

--- a/doc/modules/ROOT/pages/anlz.adoc
+++ b/doc/modules/ROOT/pages/anlz.adoc
@@ -13,6 +13,7 @@ Later player hardware added support for things like colored and more-detailed wa
 Apparently these were deemed too large to fit in the `.DAT` files (probably due to memory limitations of the older players downloading those files), so another file was introduced, which shares the same base filename as the `.DAT` file, but uses an extension of `.EXT` instead (presumably for “extended analysis”).
 And the CDJ-3000 introduced yet another variant of the file, with extension `.2EX` (double extended?), for its new 3-band waveforms.
 All three kinds of file share the same structure, but different sets of tags can be found in each.
+The 3-band waveform tags found in `.2EX` files are described in the <<three-band-preview,3-Band Preview>> and <<three-band-detail,3-Band Detail>> sections below, along with the <<waveform-3-band-calibration,small calibration tag>> that can accompany them.
 
 [#file-header]
 == Analysis File Header
@@ -457,7 +458,7 @@ This kind of section holds a fixed-width three-band preview of the track wavefor
 It is also used in rekordbox itself.
 This is stored in a second extended analysis file (with extension `.2EX`).
 It is identified by the four-character code `PWV6` and has the structure shown below.
-__len_header__ is `14`.
+__len_header__ is `14`, that is, twenty (decimal) bytes.
 
 .Waveform 3-Band Preview tag.
 [bytefield]
@@ -474,15 +475,16 @@ __len_entry_bytes__ identifies how many bytes each waveform preview entry takes 
 __len_entries__ specifies how many entries are present in the tag.
 The three-band waveform preview data begins at byte{nbsp}``14`` and is 3,600 (decimal) bytes long, representing 1,200 columns of waveform preview information.
 
-The three-band waveform preview entries are one-byte height values representing the mid-range, high, and low frequencies, in that order.
+The three-band waveform preview entries are one-byte height values representing the low, mid-range, and high frequencies, in that order.
 There is some scaling involved, and they seem to be drawn stacked on top of each other, with the lows in dark blue, the mid-range in amber, and the highs in white.
+This order was verified by analyzing rekordbox's rendition of a 20kHz→20Hz frequency sweep (where early columns must be dominated by high frequencies and later columns by low frequencies).
 
 [#three-band-detail]
 === Waveform 3-Band Detail Tag
 
 This kind of section holds a variable-width and much larger three-band rendition of the track waveform, introduced with the CDJ-3000 (and also used in rekordbox), which scrolls along while the track plays, giving a detailed glimpse of the neighborhood of the current playback position.
-This is stored in the second extended analysis file (with extension `.EXT`).
-It is identified by the four-character code `PWV7` and has the structure shown below. __len_header__ is `18`.
+This is stored in the second extended analysis file (with extension `.2EX`).
+It is identified by the four-character code `PWV7` and has the structure shown below. __len_header__ is `18`, that is, twenty-four (decimal) bytes.
 
 .Waveform 3-Band Detail tag.
 [bytefield]
@@ -502,13 +504,39 @@ Each entry represents one xref:djl-analysis:ROOT:track_metadata.adoc#frames[half
 The purpose of the header bytes{nbsp}``14``-`17` is unknown; they may always have the value `00960000`.
 The three-band waveform detail entries begin at byte{nbsp}``18``.
 
-Three-band detail entries have the same structure preview entries, one-byte height values representing the mid-range, high, and low frequencies, in that order.
+Three-band detail entries have the same structure as preview entries, one-byte height values representing the low, mid-range, and high frequencies, in that order.
+The band order is the same as in the <<three-band-preview,3-Band Preview>> tag; see the note there.
 There is a different kind of scaling involved in drawing these, and it seems to be non-linear.
 We have not yet found an approach that perfectly matches what we see in rekordbox, but we can get results that look decent.
 The colors for low, mid-range, and high frequencies are the same as in the preview, but they are drawn on the same axis rather than being stacked.
 The area where low and mid-range frequencies overlap is drawn in brown, and their pure colors are seen where there is no overlap.
 The white high frequency is drawn last so it obscures any low or mid-range information underneath it.
 Recordbox actually seems to do some light blending, but it is so dim that we have not bothered to reproduce it so far.
+
+[#waveform-3-band-calibration]
+=== Waveform 3-Band Calibration Tag
+
+This kind of section contains three per-band values that rekordbox computed while analyzing the track.
+It is stored in the second extended analysis file (with extension `.2EX`).
+It is identified by the four-character code `PWVC` and has the structure shown below.
+It is much smaller than the waveform tags: __len_header__ is `e`, that is, fourteen (decimal) bytes, and as always __len_tag__ is the length of the entire tag including the header (so far always `14`, twenty (decimal) bytes).
+
+.Waveform 3-Band Calibration tag.
+[bytefield]
+----
+include::example$tag_shared.edn[]
+(draw-tag-header "PWVC")
+(draw-box (text "unknown" :math) [:bg-yellow {:span 2}])
+(draw-box (text "thr" :math [:sub "low"]) {:span 2})
+(draw-box (text "thr" :math [:sub "mid"]) {:span 2})
+(draw-box (text "thr" :math [:sub "high"]) {:span 2})
+(draw-bottom)
+----
+
+The two-byte _unknown_ field at bytes{nbsp}``0c``-`0d` has always been observed to contain zero.
+Beginning at byte{nbsp}``0e``, there are three sixteen-bit big-endian unsigned values, _thr~low~_, _thr~mid~_, and _thr~high~_, associated with the low (dark blue), mid-range (amber), and high (white) waveform bands, respectively.
+Across a survey of 192 analyzed tracks, the xref:djl-analysis:ROOT:track_metadata.adoc#requesting-vocal-config[protocol analysis] reports observed values of 80--114 for _thr~low~_, 80--146 for _thr~mid~_, and 98--159 for _thr~high~_, and interprets them as vocal detection thresholds used to classify frequency content as vocal or non-vocal.
+The rekordcrate project instead models this tag as per-band gain calibration for the 3-band player waveform, so the exact purpose of these values is not yet settled; note also that we have seen values outside those ranges in Pioneer's own demo tracks (for example `005b`, `008a`, and `018c`).
 
 [#song-structure-tag]
 === Song Structure Tag

--- a/src/main/kaitai/rekordbox_anlz.ksy
+++ b/src/main/kaitai/rekordbox_anlz.ksy
@@ -80,8 +80,9 @@ types:
             'section_tags::wave_scroll': wave_scroll_tag                # PWV3, seen in .EXT
             'section_tags::wave_color_preview': wave_color_preview_tag  # PWV4, in .EXT
             'section_tags::wave_color_scroll': wave_color_scroll_tag    # PWV5, in .EXT
-            'section_tags::wave_3band_preview': wave_3band_preview_tag  # P@V6, in .2EX
+            'section_tags::wave_3band_preview': wave_3band_preview_tag  # PWV6, in .2EX
             'section_tags::wave_3band_scroll': wave_3band_scroll_tag    # PWV7, in .2EX
+            'section_tags::wave_3band_calibration': wave_3band_calibration_tag  # PWVC, in .2EX
             'section_tags::song_structure': song_structure_tag          # PSSI, in .EXT
             _: unknown_tag
     -webide-representation: '{fourcc}'
@@ -403,7 +404,12 @@ types:
   wave_3band_preview_tag:
     doc: |
       The minimalist CDJ-3000 waveform preview image suitable for display
-      above the touch strip for jumping to a track position.
+      above the touch strip for jumping to a track position. Each entry
+      holds three one-byte band energies stored in the order low,
+      mid-range, high (verified by analyzing rekordbox's rendition of a
+      20kHz→20Hz frequency sweep), and the bands are drawn stacked, with
+      the lows in dark blue, the mid-range in amber, and the highs in
+      white.
     seq:
       - id: len_entry_bytes
         type: u4
@@ -413,14 +419,17 @@ types:
         type: u4
         doc: |
           The number of waveform data points, each of which takes one
-          byte for each of six channels of information.
+          byte for each of three frequency bands.
       - id: entries
-        size: len_entries * len_entry_bytes
+        type: wave_3band_entry
+        repeat: expr
+        repeat-expr: len_entries
 
   wave_3band_scroll_tag:
     doc: |
       The minimalist CDJ-3000 waveform image suitable for scrolling along
-      as a track plays on newer high-resolution hardware.
+      as a track plays on newer high-resolution hardware. Entries have
+      the same three-band structure as the preview tag.
     seq:
       - id: len_entry_bytes
         type: u4
@@ -433,7 +442,41 @@ types:
           non-color waveform length.
       - type: u4
       - id: entries
-        size: len_entries * len_entry_bytes
+        type: wave_3band_entry
+        repeat: expr
+        repeat-expr: len_entries
+
+  wave_3band_calibration_tag:
+    doc: |
+      Accompanies the 3-band waveforms in .2EX analysis files. Contains
+      three sixteen-bit big-endian values associated with the low,
+      mid-range, and high waveform bands. The protocol analysis
+      interprets them as vocal detection thresholds, while the
+      rekordcrate project models them as per-band gain calibration, so
+      their exact purpose is not yet settled.
+    seq:
+      - id: unknown
+        type: u2
+        doc: |
+          Has always been observed to contain zero.
+      - id: low
+        type: u2
+      - id: mid
+        type: u2
+      - id: high
+        type: u2
+
+  wave_3band_entry:
+    doc: |
+      Describes the band energies of one column of a CDJ-3000 three-band
+      waveform, in the order low, mid-range, high.
+    seq:
+      - id: low
+        type: u1
+      - id: mid
+        type: u1
+      - id: high
+        type: u1
 
   song_structure_tag:
     doc: |
@@ -611,6 +654,7 @@ enums:
     0x50535349: song_structure      # PSSI (seen in .EXT)
     0x50575636: wave_3band_preview  # PWV6 (seen in .2EX)
     0x50575637: wave_3band_scroll   # PWV7 (seen in .2EX)
+    0x50575643: wave_3band_calibration  # PWVC (seen in .2EX)
 
   cue_list_type:
     0: memory_cues


### PR DESCRIPTION
Rationale: the documentation for the CDJ-3000's `.2EX` analysis files was incomplete and, for the order of the three waveform bands, actively wrong, which can mislead anyone implementing 3-band waveform rendering (issue #22).

Fixes #22

This PR improves `doc/modules/ROOT/pages/anlz.adoc`:

- **Corrects the band order in PWV6 (3-Band Preview) and PWV7 (3-Band Detail) entries** to low, mid-range, high. This was verified against rekordbox's own analysis of a 20kHz→20Hz frequency sweep, in which early columns (high frequencies) are dominated by the third byte and later columns (low frequencies) by the first byte. It also adds a note that this contradicts the djl-analysis protocol description and Beat Link's `segmentHeight`, so those may deserve a second look.
- **Fixes the PWV7 storage location**: the section said the tag is stored in `.EXT` files, but it lives in `.2EX` files along with `PWV6` and `PWVC`. Cross-references to these sections were also added from the intro's mention of `.2EX` files.
- **Adds a Waveform 3-Band Calibration Tag section for `PWVC`**, documenting its observed structure (two bytes always zero so far, followed by three big-endian sixteen-bit per-band values, with `len_header` of `0e` and `len_tag` of `14` in demo exports). It presents both competing interpretations of the values: the djl-analysis book's vocal detection thresholds (with its 192-track observed ranges) and rekordcrate's per-band gain calibration modeling. Decimal equivalents were added alongside the hexadecimal header lengths in the 3-band sections to avoid ambiguity.
- Adds a changelog entry under **Unreleased → Fixed**.

Verification details: the band-order conclusions were confirmed by parsing `PWV6`/`PWV7` data from rekordbox's analysis of a sine sweep (early sweep columns must be high-frequency dominated, later columns low-frequency dominated); `PWVC` structure and values were checked against the `.2EX` files shipped in Pioneer's demo tracks.